### PR TITLE
Fix serverless volumes of docker-compose

### DIFF
--- a/dockers/docker-compose.yml
+++ b/dockers/docker-compose.yml
@@ -9,11 +9,7 @@ services:
       LAMBDA_ROLE: 'dummy'
       DEPLOY_BUCKET: 'dummy'
     volumes:
-      - ../package.json:/app/package.json
-      - ../package-lock.json:/app/package-lock.json
-      - ../tsconfig.json:/app/tsconfig.json
-      - ../tslint.json:/app/tslint.json
-      - ../serverless.yml:/app/serverless.yml
-      - ../source-map-install.js:/app/source-map-install.js
-      - ../webpack.config.js:/app/webpack.config.js
-      - ../handler.ts:/app/handler.ts
+      - ../:/app/
+      - ./serverless/node_modules/:/app/node_modules/
+      - ./serverless/.serverless/:/app/.serverless/
+      - ./serverless/.webpack/:/app/.webpack/

--- a/dockers/serverless/Dockerfile
+++ b/dockers/serverless/Dockerfile
@@ -4,5 +4,4 @@ RUN apk upgrade
 RUN apk update
 RUN npm install -g serverless@1.30.0
 
-RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
Because `npm install --save-dev` is failed in docker.
```
/app # npm install --save-dev serverless-offline
npm WARN saveError EBUSY: resource busy or locked, rename '/app/package.json.1075790975' -> '/app/package.json'
npm WARN saveError EBUSY: resource busy or locked, rename '/app/package-lock.json.3578425104' -> '/app/package-lock.json'
```