### PR TITLE
Remove mapping temporary dir from docker volumes

### DIFF
--- a/dockers/docker-compose.yml
+++ b/dockers/docker-compose.yml
@@ -10,6 +10,3 @@ services:
       DEPLOY_BUCKET: 'dummy'
     volumes:
       - ../:/app/
-      - ./serverless/node_modules/:/app/node_modules/
-      - ./serverless/.serverless/:/app/.serverless/
-      - ./serverless/.webpack/:/app/.webpack/


### PR DESCRIPTION
temporary dirs:
* node_modules
* .serverless
* .webpack