### PR TITLE
Add CRUD of todo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,12 @@
       "integrity": "sha512-WXvAXaknB0c2cJ7N44e1kUrVu5K90mSfPPaT5XxfuSMxEWva86EYIwxUZM3jNZ2P1CIC9e2z4WJqpAF69PQxeA==",
       "dev": true
     },
+    "@types/validator": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-Y8UyLZvBPgckGhEIFCGBPj1tsRbpcZn4rbAp7lUxC3EW/nDR2V6t9LltE+mvDJxQQ+Bg3saE3UAwn6lsG5O1yQ==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.13.tgz",
@@ -5202,6 +5208,11 @@
       "requires": {
         "homedir-polyfill": "1.0.1"
       }
+    },
+    "validator": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.6.0.tgz",
+      "integrity": "sha512-/yVPLo/GYprbhK9m9Qi9T7XSJ/lZ9rnqerlN68yH4c1/raGHoxlE7TtirN2VcP4w27Qvyv8UHJ/SUIjntPhPCw=="
     },
     "velocityjs": {
       "version": "0.9.6",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
   "dependencies": {
     "dynamodb": "^1.1.2",
     "joi": "^13.6.0",
-    "source-map-support": "^0.5.0"
+    "source-map-support": "^0.5.0",
+    "validator": "^10.6.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.1",
     "@types/joi": "^13.4.3",
     "@types/node": "^8.0.57",
+    "@types/validator": "^9.4.1",
     "prettier": "^1.14.2",
     "serverless-offline": "^3.25.8",
     "serverless-webpack": "^5.1.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -40,3 +40,9 @@ functions:
       - http:
           path: todos
           method: get
+  get:
+    handler: src/controllers/todos.get
+    events:
+      - http:
+          path: todos/{id}
+          method: get

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,3 +28,9 @@ functions:
       - http:
           method: get
           path: maintenances/init
+  create:
+    handler: src/controllers/todos.create
+    events:
+      - http:
+          path: todos
+          method: post

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,3 +52,9 @@ functions:
       - http:
           path: todos/{id}
           method: put
+  delete:
+    handler: src/controllers/todos.destroy
+    events:
+      - http:
+          path: todos/{id}
+          method: delete

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,3 +34,9 @@ functions:
       - http:
           path: todos
           method: post
+  list:
+    handler: src/controllers/todos.list
+    events:
+      - http:
+          path: todos
+          method: get

--- a/serverless.yml
+++ b/serverless.yml
@@ -46,3 +46,9 @@ functions:
       - http:
           path: todos/{id}
           method: get
+  update:
+    handler: src/controllers/todos.update
+    events:
+      - http:
+          path: todos/{id}
+          method: put

--- a/src/controllers/todos.ts
+++ b/src/controllers/todos.ts
@@ -94,3 +94,58 @@ export const get: Handler = (
       });
     });
 };
+
+export const update: Handler = (
+  event: APIGatewayEvent,
+  _: Context,
+  cb: Callback
+) => {
+  if (!event.pathParameters) {
+    console.error("Validation Failed");
+    cb(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Couldn't update the todo item. id"
+      })
+    });
+    return;
+  }
+  const input = JSON.parse(event.body || "{}");
+  if (!input.text || validator.isEmpty(input.text)) {
+    console.error("Validation Failed");
+    cb(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Couldn't update the todo item. text"
+      })
+    });
+    return;
+  }
+  if (!input.checked || !validator.isBoolean(input.checked)) {
+    console.error("Validation Failed");
+    cb(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Couldn't update the todo item. checked"
+      })
+    });
+    return;
+  }
+  new Todos()
+    .update(event.pathParameters.id, input.text, input.checked)
+    .then(todo => {
+      cb(null, {
+        statusCode: 200,
+        body: JSON.stringify(todo)
+      });
+    })
+    .catch(error => {
+      console.error(error);
+      cb(null, {
+        statusCode: error.statusCode || 501,
+        body: JSON.stringify({
+          message: "Couldn't update the todo item."
+        })
+      });
+    });
+};

--- a/src/controllers/todos.ts
+++ b/src/controllers/todos.ts
@@ -149,3 +149,37 @@ export const update: Handler = (
       });
     });
 };
+
+export const destroy: Handler = (
+  event: APIGatewayEvent,
+  _: Context,
+  cb: Callback
+) => {
+  if (!event.pathParameters) {
+    console.error("Validation Failed");
+    cb(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Couldn't remove the todo item."
+      })
+    });
+    return;
+  }
+  new Todos()
+    .delete(event.pathParameters.id)
+    .then(() => {
+      cb(null, {
+        statusCode: 200,
+        body: JSON.stringify({})
+      });
+    })
+    .catch(error => {
+      console.error(error);
+      cb(null, {
+        statusCode: error.statusCode || 501,
+        body: JSON.stringify({
+          message: "Couldn't remove the todo item."
+        })
+      });
+    });
+};

--- a/src/controllers/todos.ts
+++ b/src/controllers/todos.ts
@@ -36,3 +36,27 @@ export const create: Handler = (
       });
     });
 };
+
+export const list: Handler = (
+  _event: APIGatewayEvent,
+  _: Context,
+  cb: Callback
+) => {
+  new Todos()
+    .all()
+    .then(todos => {
+      cb(null, {
+        statusCode: 200,
+        body: JSON.stringify(todos)
+      });
+    })
+    .catch(error => {
+      console.error(error);
+      cb(null, {
+        statusCode: error.statusCode || 501,
+        body: JSON.stringify({
+          message: "Couldn't fetch the todos."
+        })
+      });
+    });
+};

--- a/src/controllers/todos.ts
+++ b/src/controllers/todos.ts
@@ -60,3 +60,37 @@ export const list: Handler = (
       });
     });
 };
+
+export const get: Handler = (
+  event: APIGatewayEvent,
+  _: Context,
+  cb: Callback
+) => {
+  if (!event.pathParameters) {
+    console.error("Validation Failed");
+    cb(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Couldn't fetch the todo item."
+      })
+    });
+    return;
+  }
+  new Todos()
+    .get(event.pathParameters.id)
+    .then(todo => {
+      cb(null, {
+        statusCode: 200,
+        body: JSON.stringify(todo)
+      });
+    })
+    .catch(error => {
+      console.error(error);
+      cb(null, {
+        statusCode: error.statusCode || 501,
+        body: JSON.stringify({
+          message: "Couldn't fetch the todo item."
+        })
+      });
+    });
+};

--- a/src/controllers/todos.ts
+++ b/src/controllers/todos.ts
@@ -1,0 +1,38 @@
+import { APIGatewayEvent, Callback, Context, Handler } from "aws-lambda";
+import * as validator from "validator";
+import { Todos } from "../models/Todos";
+
+export const create: Handler = (
+  event: APIGatewayEvent,
+  _: Context,
+  cb: Callback
+) => {
+  const input = JSON.parse(event.body || "{}");
+  if (!input.text || validator.isEmpty(input.text)) {
+    console.error("Validation Failed");
+    cb(null, {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Couldn't create the todo item."
+      })
+    });
+    return;
+  }
+  new Todos()
+    .create(input.text)
+    .then(todo => {
+      cb(null, {
+        statusCode: 200,
+        body: JSON.stringify(todo)
+      });
+    })
+    .catch(error => {
+      console.error(error);
+      cb(null, {
+        statusCode: error.statusCode || 501,
+        body: JSON.stringify({
+          message: "Couldn't create the todo item."
+        })
+      });
+    });
+};

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -1,5 +1,6 @@
 import * as AWS from "aws-sdk";
 import * as dynamo from "dynamodb";
+import * as Joi from "joi";
 
 let options = {};
 if (process.env.IS_OFFLINE) {
@@ -17,12 +18,18 @@ if (process.env.IS_OFFLINE) {
 dynamo.dynamoDriver(new AWS.DynamoDB(options));
 
 export class Todos {
+  private schema: any;
+
   constructor() {
-    dynamo.define(this.tableName(), {
+    this.schema = dynamo.define(this.tableName(), {
       hashKey: "id",
       timestamps: false,
       schema: {
-        id: dynamo.types.uuid()
+        id: dynamo.types.uuid(),
+        text: Joi.string(),
+        checked: Joi.boolean().default(false),
+        createdAt: Joi.number(),
+        updatedAt: Joi.number().default(Date.now, "timestamp")
       }
     });
   }

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -73,6 +73,18 @@ export class Todos {
     });
   }
 
+  public get(id: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.schema
+        .get(id, (err: any, result: any) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(result.get());
+        });
+    });
+  }
+
   public createTable(): Promise<void> {
     return new Promise((resolve, reject) => {
       let createOptions: { [key: string]: any } = {};

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -56,6 +56,23 @@ export class Todos {
     });
   }
 
+  public all(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.schema
+        .scan()
+        .loadAll()
+        .exec((err: any, result: any) => {
+          if (err) {
+            return reject(err);
+          }
+          if (result.Count === 0 || !result.Items) {
+            return resolve([]);
+          }
+          resolve(result.Items.map((item: any) => item.get()));
+        });
+    });
+  }
+
   public createTable(): Promise<void> {
     return new Promise((resolve, reject) => {
       let createOptions: { [key: string]: any } = {};

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -79,6 +79,9 @@ export class Todos {
         if (err) {
           return reject(err);
         }
+        if (!result) {
+          return resolve({});
+        }
         resolve(result.get());
       });
     });

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -75,13 +75,12 @@ export class Todos {
 
   public get(id: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.schema
-        .get(id, (err: any, result: any) => {
-          if (err) {
-            return reject(err);
-          }
-          resolve(result.get());
-        });
+      this.schema.get(id, (err: any, result: any) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(result.get());
+      });
     });
   }
 

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -34,6 +34,28 @@ export class Todos {
     });
   }
 
+  public create(text: string): Promise<any> {
+    const timestamp = new Date().getTime();
+
+    return new Promise((resolve, reject) => {
+      this.schema.create(
+        {
+          text: text,
+          createdAt: timestamp,
+          updatedAt: timestamp
+        },
+        function(err: any, todo: any) {
+          if (err) {
+            reject(err);
+          } else {
+            console.log("created account in DynamoDB", todo.get("text"));
+            resolve(todo.get());
+          }
+        }
+      );
+    });
+  }
+
   public createTable(): Promise<void> {
     return new Promise((resolve, reject) => {
       let createOptions: { [key: string]: any } = {};

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -28,21 +28,17 @@ export class Todos {
         id: dynamo.types.uuid(),
         text: Joi.string(),
         checked: Joi.boolean().default(false),
-        createdAt: Joi.number(),
+        createdAt: Joi.number().default(Date.now, "timestamp"),
         updatedAt: Joi.number().default(Date.now, "timestamp")
       }
     });
   }
 
   public create(text: string): Promise<any> {
-    const timestamp = new Date().getTime();
-
     return new Promise((resolve, reject) => {
       this.schema.create(
         {
-          text: text,
-          createdAt: timestamp,
-          updatedAt: timestamp
+          text: text
         },
         function(err: any, todo: any) {
           if (err) {
@@ -89,11 +85,13 @@ export class Todos {
 
   public update(id: string, text: string, checked: boolean): Promise<any> {
     return new Promise((resolve, reject) => {
+      const timestamp = new Date().getTime();
       this.schema.update(
         {
           id: id,
           text: text,
-          checked: checked
+          checked: checked,
+          updatedAt: timestamp
         },
         (err: any, result: any) => {
           if (err) {

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -44,7 +44,7 @@ export class Todos {
           if (err) {
             reject(err);
           } else {
-            console.log("created account in DynamoDB", todo.get("text"));
+            console.log("created todo in DynamoDB", todo.get("text"));
             resolve(todo.get());
           }
         }

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -84,6 +84,24 @@ export class Todos {
     });
   }
 
+  public update(id: string, text: string, checked: boolean): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.schema.update(
+        {
+          id: id,
+          text: text,
+          checked: checked
+        },
+        (err: any, result: any) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(result.get());
+        }
+      );
+    });
+  }
+
   public createTable(): Promise<void> {
     return new Promise((resolve, reject) => {
       let createOptions: { [key: string]: any } = {};

--- a/src/models/Todos.ts
+++ b/src/models/Todos.ts
@@ -102,6 +102,17 @@ export class Todos {
     });
   }
 
+  public delete(id: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.schema.destroy(id, (err: any) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
+    });
+  }
+
   public createTable(): Promise<void> {
     return new Promise((resolve, reject) => {
       let createOptions: { [key: string]: any } = {};


### PR DESCRIPTION
Create:
```bash
$ curl -X POST http://localhost:3000/todos --data '{ "text": "foo" }'
```

List all:
```bash
$ curl http://localhost:3000/todos
```

Get one:
```bash
$ curl http://localhost:3000/todos/<id>
```

Update:
```bash
$ curl -X PUT http://localhost:3000/todos/<id> --data '{ "text": "bar", "checked": "true" }'
```

Delete:
```bash
$ curl -X DELETE http://localhost:3000/todos/<id>
```

I referred to this.
https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb