### PR TITLE
Change API Gateway endpointType to REGIONAL

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
     runtime-versions:
       nodejs: 8
     commands:
-      - npm install -g serverless@1.30.0
+      - npm install -g serverless@1.49.0
       - npm install
   build:
     commands:

--- a/dockers/serverless/Dockerfile
+++ b/dockers/serverless/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8.10.0-alpine
 
 RUN apk upgrade
 RUN apk update
-RUN npm install -g serverless@1.30.0
+RUN npm install -g serverless@1.49.0
 RUN npm install -g npm-check-updates
 
 WORKDIR /src

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,6 +8,7 @@ plugins:
 
 provider:
   name: aws
+  endpointType: REGIONAL
   runtime: nodejs8.10
   region: ap-northeast-1
   stage: ${env:STAGE_ENV}


### PR DESCRIPTION
https://serverless.com/framework/docs/providers/aws/events/apigateway/#configuring-endpoint-types

> By default, the Serverless Framework deploys your REST API using the EDGE endpoint configuration. 

Since CloudFront is used, make it `REGIONAL`.
